### PR TITLE
Extract boostrap_app logic to simplify app bootstrap for testing

### DIFF
--- a/sowba/cli/__init__.py
+++ b/sowba/cli/__init__.py
@@ -90,7 +90,8 @@ def run(storage: StorageName = typer.Option(None, "--settings-storage")):
     typer.echo(f"app: {settings.name}")
     typer.echo(f"storage: {storage}")
 
-    app = bootstrap_app(settings, storage)
+    bootstrap_app(settings, None, storage)
+    app = get_registry.app()
     devtools.debug(settings.asgi)
     run_app(app, settings)
 

--- a/sowba/cli/utils.py
+++ b/sowba/cli/utils.py
@@ -18,7 +18,7 @@ from cookiecutter.exceptions import OutputDirExistsException
 
 
 import pathlib
-from typing import Dict
+from typing import Dict, List
 from pydantic import FilePath
 from pydantic.parse import load_file
 
@@ -133,13 +133,15 @@ def load_sevcurity(app: SApp):
 
 def bootstrap_app(
     settings: AppSettings,
+    service_filter: List[str] = None,
     storage: StorageName = None,
 ):
     app = make_app(settings)
     if getattr(settings, "auth", None):
         load_sevcurity(app)
 
-    for i, srv in enumerate(settings.services):
+    services = service_filter if service_filter is not None else enumerate(settings.services)
+    for i, srv in services:
         if srv.status == ServiceStatus.disable:
             continue
         if storage is not None:

--- a/sowba/cli/utils.py
+++ b/sowba/cli/utils.py
@@ -134,7 +134,7 @@ def load_sevcurity(app: SApp):
 def bootstrap_app(
     settings: AppSettings,
     storage: StorageName = None,
-) -> SApp:
+):
     app = make_app(settings)
     if getattr(settings, "auth", None):
         load_sevcurity(app)
@@ -161,4 +161,4 @@ def bootstrap_app(
             },
         )
     add_registry.app_settings(settings)
-    return app
+    add_registry.app(app)


### PR DESCRIPTION
In order to run integration tests using FastAPI.testclient.TestClient, we need to have access to the app object (https://fastapi.tiangolo.com/tutorial/testing/). 

As such, I have moved the common bootstrap logic from the project start function to use a function which stores that object in the registry. This is also planned to be used in the tests as well.